### PR TITLE
fix(packaging): remove the broken console script and unused dependencies

### DIFF
--- a/polyphys/tests/test_packaging.py
+++ b/polyphys/tests/test_packaging.py
@@ -1,0 +1,64 @@
+"""
+Tests for :mod:`polyphys` distribution metadata.
+
+These tests guard the packaging contract declared in ``pyproject.toml``
+against defects that are invisible to the rest of the test suite because
+they only surface in an *installed* copy of the package: an entry point
+naming a module that does not exist, or a malformed version string.
+"""
+import re
+from importlib.metadata import PackageNotFoundError, distribution
+
+import pytest
+
+from polyphys.__version__ import __version__
+
+#: ``MAJOR.MINOR.PATCH`` with an optional pre-release/build suffix.
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
+)
+
+
+def _polyphys_distribution():
+    """
+    Return the installed ``polyphys`` distribution, or skip the test.
+
+    Skipping keeps the suite runnable from a bare source checkout, where
+    no distribution metadata exists to inspect.
+    """
+    try:
+        return distribution("polyphys")
+    except PackageNotFoundError:  # pragma: no cover - depends on install
+        pytest.skip("polyphys is not installed; no metadata to inspect")
+
+
+def test_version_is_valid_semver() -> None:
+    """``__version__`` must be a valid semantic version string.
+
+    Guards the release process: ``pyproject.toml`` reads this attribute
+    dynamically, so a malformed value produces a broken distribution.
+    """
+    assert SEMVER_RE.match(__version__), (
+        f"__version__ = {__version__!r} is not valid semantic versioning"
+    )
+
+
+def test_declared_console_scripts_are_importable() -> None:
+    """Every declared console script must resolve to a real callable.
+
+    Regression test: the distribution previously declared
+    ``polyphys = polyphys.cli:main`` while ``polyphys/cli.py`` did not
+    exist, so every install shipped a command that raised
+    ``ModuleNotFoundError`` when run.
+    """
+    dist = _polyphys_distribution()
+    scripts = [
+        ep for ep in dist.entry_points if ep.group == "console_scripts"
+    ]
+    for entry_point in scripts:
+        target = entry_point.load()
+        assert callable(target), (
+            f"console script {entry_point.name!r} points at "
+            f"{entry_point.value!r}, which is not callable"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,15 +21,7 @@
     requires-python = ">=3.11"
     dependencies = [
         "numpy",
-        "pandas",
-        "scipy",
-        "matplotlib",
-        "seaborn",
-        "MDAnalysis",
-        "statsmodels",
-        "pyarrow",
-        "packaging",
-        "click"
+        "pandas"
     ]
 
 [project.optional-dependencies]
@@ -57,19 +49,14 @@
     ]
 
 [project.urls]
-    Source = "https://github.com/amirhs1/PolyPhys"
-
-[project.scripts]
-    polyphys = "polyphys.cli:main"
+    Source = "https://github.com/amirhs1/poly-phys"
+    Issues = "https://github.com/amirhs1/poly-phys/issues"
 
 [tool.setuptools]
     include-package-data = true
 
 [tool.setuptools.dynamic]
     version = {attr = "polyphys.__version__.__version__"}
-
-[tool.setuptools.package-data]
-    "polyphys.test_data" = ["**/*"]
 
 [tool.setuptools.packages.find]
     include = ["polyphys*"]


### PR DESCRIPTION
## Summary

The distribution declared packaging metadata that did not match the source tree. These defects are invisible to the test suite because they only surface in an **installed** copy of the package.

## Defects fixed

| # | Defect | Impact |
|---|---|---|
| 1 | `[project.scripts]` declared `polyphys = polyphys.cli:main`, but `polyphys/cli.py` does not exist | Every install shipped a command that crashed |
| 2 | `[tool.setuptools.package-data]` referenced `polyphys.test_data`, not a package in this tree | Dead metadata |
| 3 | 8 of 10 runtime dependencies never imported anywhere | Users forced to install MDAnalysis, SciPy, Matplotlib for a package importing none of them |
| 4 | `[project.urls]` pointed at the pre-rename `amirhs1/PolyPhys` path | Stale link |

Reproduction of (1) on the previously installed copy:

```
$ polyphys --help
ModuleNotFoundError: No module named 'polyphys.cli'
```

On (3), the unused dependencies were `scipy`, `matplotlib`, `seaborn`, `statsmodels`, `pyarrow`, `packaging`, `click`, and `MDAnalysis`. `MDAnalysis` appeared only inside a docstring URL in `polyphys/analyze/measurer.py`. Runtime dependencies are now `numpy` and `pandas`.

The CLI entry point is removed rather than backfilled; a CLI is deferred to a later phase and can be reintroduced once there is a module behind it.

## Tests

Adds `polyphys/tests/test_packaging.py` (2 tests), which validates the packaging contract against installed distribution metadata:

- every declared `console_scripts` entry point resolves to a callable — a direct regression guard on defect (1);
- `__version__` is valid semantic versioning, since `pyproject.toml` reads it dynamically.

## Verification

All run in the `polylab_air` environment unless noted.

| Check | Result |
|---|---|
| `python -m flake8 polyphys` | clean |
| `python -m mypy polyphys/analyze polyphys/manage` | Success: no issues found in 7 source files |
| `python -m pytest polyphys README.md --doctest-modules --doctest-glob=README.md` | **259 passed, 21 skipped** (was 257 + 2 new) |
| `python -m build` | sdist + wheel built (disposable venv — `build` is declared in `[dev]` but not installed in `polylab_air`) |
| Clean-install check | wheel installed into an empty venv |

The clean-install check confirms both the entry-point and dependency fixes end to end:

- the built wheel contains **no** `entry_points.txt`, and no `polyphys` command is created;
- with only `numpy 2.5.1` and `pandas 3.0.5` installed, `polyphys`, `manage.{parser,organizer,utils,types}` and `analyze.measurer` all import, and all 8 `ParserBase` subclasses load.

## Notes for review

- No source behaviour changes — packaging metadata and one new test module only.
- Dependency **removals** only; nothing added or upgraded. No version bounds introduced.
- Targets the v0.4.0 release. `polyphys/__version__.py` already reads `0.4.0`; no version change in this PR.