### PR TITLE
docs(github): adopt the shared naming convention and label taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Report reproducible behavior that looks incorrect
-title: ""
-labels: bug
+title: "[area] "
+labels: type:bug
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Propose an improvement or new capability
-title: ""
-labels: enhancement
+title: "[area] "
+labels: type:feature
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,8 @@
 ---
 name: Question
 about: Ask about usage, installation, or project direction
-title: ""
-labels: question
+title: "[area] "
+labels: type:question
 assignees: ""
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+<!--
+Title: type(scope): imperative summary -- see docs/NAMING-CONVENTION.md
+Put `Closes #N` in the Summary below, never in the title.
+-->
+
 ## Summary
 
 -
@@ -6,9 +11,9 @@
 
 - [ ] `flake8 polyphys`
 - [ ] `mypy polyphys/analyze polyphys/manage`
-- [ ] `pytest polyphys --ignore=polyphys/tests/manage/test_parser.py --ignore=polyphys/manage/parser.py --ignore=polyphys/manage/organizer.py --cov=polyphys --cov-report=term-missing --doctest-modules --doctest-glob="README.md"`
+- [ ] `pytest polyphys README.md --cov=polyphys --cov-report=term-missing --doctest-modules --doctest-glob="README.md"`
 - [ ] `python -m build` if packaging metadata, package data, or package layout changed
-- [ ] Docs build if `docs/source/` changed
+- [ ] `python -m sphinx -W -b html docs/source docs/_build` if `docs/source/` changed
 
 ## Scientific Correctness
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    # Declared explicitly: without this key Dependabot recreates its default
+    # `dependencies` label, which this repository renamed to `type:deps`.
+    labels:
+      - "type:deps"
+      - "area:ci"
     groups:
       github-actions:
         patterns:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,15 +112,25 @@ The only long-lived branch is `main`; there is no `develop` branch.
 
 - Never commit or push directly to `main`.
 - Use one focused non-`main` branch per meaningful task where practical.
-- Branch prefix determines the single routine PR label:
-  - `feature/*` → `enhancement`
-  - `fix/*` or `hotfix/*` → `bug`
-  - `refactor/*` or `chore/*` → `chore`
-  - `deps/*` → `dependencies`
-  - `docs/*` → `documentation`
-  - `help/*` → `help wanted`
-  - `question/*` → `question`
-  - `release/*` → `release`
+- Use `docs/NAMING-CONVENTION.md` for names. Commit subjects and PR titles use
+  `type(scope): imperative summary`; issue titles use `[area] Verb object`;
+  milestones use `vX.Y.Z — Release Name`.
+- Branch prefix determines the single routine PR type label:
+  - `feat/*` → `type:feature`
+  - `fix/*` or `hotfix/*` → `type:bug`
+  - `docs/*` → `type:docs`
+  - `test/*` → `type:test`
+  - `ci/*` → `type:ci`
+  - `refactor/*` or `chore/*` → `type:refactor`
+  - `deps/*` → `type:deps`
+  - `release/*` → `type:release`
+- Additionally apply one or more `area:*` labels naming the affected subsystem
+  (`area:manage`, `area:analyze`, `area:packaging`, `area:documentation`,
+  `area:ci`, `area:agents`). The `blocked`, `technical-debt`, and
+  `breaking-change` labels are orthogonal and combine with any type.
+- Labels carry type and area only. Status and priority live in the GitHub
+  Project fields, and the release lives in the milestone; do not encode either
+  as a label.
 - When the current task explicitly authorizes a focused implementation, that authorization covers creating the branch, editing code/tests/docs, making coherent commits, pushing the focused branch, opening or updating a draft PR, and applying the matching routine label. Do not ask again for each routine step.
 - Before the first push, inspect `git status --short` and the complete branch-versus-base diff; check for unrelated files, generated artifacts, secrets, private data, and accidental deletions; and run relevant checks.
 - After maintainer review begins, do not amend published commits, rebase, or force-push unless requested or explicitly approved.

--- a/docs/NAMING-CONVENTION.md
+++ b/docs/NAMING-CONVENTION.md
@@ -1,0 +1,245 @@
+# PolyPhys Naming Conventions
+
+This file defines the naming rules for issues, labels, branches, commits, pull
+requests, milestones, and releases in the `poly-phys` repository.
+
+The goal is to make the GitHub Project easy to scan and to keep the history
+consistent. These conventions are shared with `amirhs1/CareerDossierTeX`, so a
+reader who knows one repository already knows the other.
+
+## 1. Core rule
+
+Use different naming styles for different GitHub objects:
+
+| Object | Convention | Example |
+|---|---|---|
+| Issue title | `[area] Verb object` | `[organizer] Raise test coverage to 85 percent` |
+| Epic issue title | `[epic] Release version goal` | `[epic] Release v0.5.0 trustworthy ensemble statistics` |
+| Branch name | `type/short-description` | `test/organizer-coverage` |
+| Commit message | `type(scope): imperative summary` | `test(organizer): cover the ensemble reducers` |
+| Pull request title | `type(scope): imperative summary` | `fix(packaging): drop the broken console script` |
+| Label | `type:*` or `area:*` | `type:test`, `area:manage` |
+| Milestone | `vX.Y.Z — Release Name` | `v0.5.0 — Trustworthy Ensemble Statistics` |
+| Tag | `vX.Y.Z` | `v0.4.0` |
+| GitHub Release title | `PolyPhys vX.Y.Z — Release Name` | `PolyPhys v0.4.0 — Release Readiness` |
+
+Do not force one convention onto every object. Issues, branches, commits, pull
+requests, and labels serve different purposes.
+
+---
+
+## 2. Issue title convention
+
+Use:
+
+```text
+[area] Verb object
+```
+
+Examples:
+
+```text
+[organizer] Replace skipped doctests with executable examples
+[organizer] Raise test coverage from 13 percent to at least 85 percent
+[analyze] Add autocorrelation-aware error estimation for correlated frames
+[parser] Move per-project constants onto parser classes
+[docs] Document time and space complexity for the organizer reducers
+[packaging] Remove the unused runtime dependencies
+[ci] Fail the build on Sphinx warnings
+[release] Tag and archive v0.4.0
+```
+
+### Epic issue titles
+
+Use lowercase `[epic]` for visual consistency with the other bracket prefixes:
+
+```text
+[epic] Release v0.5.0 trustworthy ensemble statistics
+```
+
+---
+
+## 3. Branch naming convention
+
+Use:
+
+```text
+type/short-description
+```
+
+Allowed branch types:
+
+```text
+feat/      fix/      docs/      test/
+ci/        refactor/ chore/     release/
+```
+
+Examples:
+
+```text
+fix/packaging-metadata
+docs/release-readiness
+docs/naming-convention
+test/organizer-coverage
+feat/block-averaging
+refactor/parser-dump-keyword
+release/v0.4.0
+```
+
+Rules:
+
+- Use lowercase.
+- Use hyphens, not spaces or underscores.
+- Keep the name short but specific.
+- Match the branch type to the main purpose of the work.
+- Do not include issue numbers unless you find them useful later.
+
+---
+
+## 4. Commit message convention
+
+Use a lightweight Conventional Commits style:
+
+```text
+type(scope): imperative summary
+```
+
+Examples:
+
+```text
+fix(packaging): remove the broken console script
+feat(analyze): add block-averaged error estimation
+test(organizer): cover the ensemble reducers
+docs(sphinx): generate the API reference
+refactor(parser): move the dump keyword onto the parser class
+ci(build): fail the docs job on Sphinx warnings
+release: prepare v0.4.0
+```
+
+### Commit types
+
+```text
+feat      New user-facing or maintainer-facing feature
+fix       Bug fix
+docs      Documentation-only change
+test      Tests, doctests, examples, or regression coverage
+ci        GitHub Actions or automation changes
+refactor  Code restructuring without changing public behavior
+chore     Maintenance that does not fit another type
+release   Version, changelog, tag, or release preparation
+```
+
+### Scopes
+
+Use the scope to identify the part of the repository affected:
+
+```text
+parser      organizer   utils       types
+measurer    analyze     manage
+packaging   sphinx      docs
+ci          github      release     agents
+```
+
+Rules:
+
+- Write the summary in the imperative mood: `add`, `define`, `fix`, `prepare`.
+- Keep the first line short.
+- Do not combine unrelated changes in one commit.
+- Prefer one coherent change per commit.
+
+### Commit body
+
+The body explains *why* before *what*. State the problem the change addresses,
+then the change, then its boundaries. Report only checks that actually ran, with
+their real outcomes. Put trailers in one final block separated by a blank line;
+see the attribution rules in `AGENTS.md`.
+
+---
+
+## 5. Pull request title convention
+
+Use the same style as commit messages:
+
+```text
+type(scope): imperative summary
+```
+
+Rules:
+
+- A pull-request title describes the whole branch, not every small commit.
+- Use `Closes #N` in the pull-request body, never in the title.
+- Do not close a large epic from an early implementation pull request. Close the
+  focused sub-issue instead.
+- Use draft pull requests for unfinished branches that need CI or notes.
+- Do not add agent or tool prefixes to pull-request titles.
+
+---
+
+## 6. Label naming convention
+
+Use labels as metadata, not as titles.
+
+### Type labels
+
+Apply exactly one primary type label when possible:
+
+```text
+type:feature   type:bug       type:docs     type:test
+type:ci        type:refactor  type:release  type:deps
+type:question
+```
+
+The branch prefix determines the type label; see `AGENTS.md`.
+
+### Area labels
+
+Use one or more area labels when useful:
+
+```text
+area:manage    area:analyze   area:packaging
+area:documentation            area:ci        area:agents
+```
+
+### State and contributor labels
+
+Use only when needed:
+
+```text
+blocked   technical-debt   breaking-change   help-wanted
+```
+
+Rules:
+
+- Do not use labels for status. Use the Project `Status` field.
+- Do not use labels for priority. Use the Project `Priority` field.
+- Do not use labels for release numbers. Use GitHub milestones.
+- Do not duplicate information already shown by GitHub fields.
+
+---
+
+## 7. Milestone, tag, and release naming
+
+Milestones represent releases:
+
+```text
+vX.Y.Z — Release Name
+```
+
+Examples:
+
+```text
+v0.4.0 — Release Readiness
+v0.5.0 — Trustworthy Ensemble Statistics
+v0.6.0 — Project Decoupling
+v0.7.0 — Observables
+v1.0.0 — Stable API
+```
+
+Tags use semantic versions (`vX.Y.Z`). GitHub Release titles use
+`PolyPhys vX.Y.Z — Release Name`.
+
+Rules:
+
+- Issues and pull requests can belong to milestones.
+- Do not create labels like `v0.4.0`; the milestone already tracks this.
+- Only the maintainer publishes a release or moves a tag.


### PR DESCRIPTION
Third of three PRs preparing the **v0.4.0** release, alongside #11 (packaging) and #12 (documentation). All three touch disjoint files and can merge in any order.

## Summary

The repository had no written naming standard, and its flat label set (`bug`, `documentation`, `enhancement`, `chore`, …) diverged from the `type:*`/`area:*` taxonomy already in use in [`amirhs1/CareerDossierTeX`](https://github.com/amirhs1/CareerDossierTeX). Two repositories governed by one written standard read as an engineering practice; two with ad-hoc differences read as neither.

This adopts that convention here and writes it down, so it is the contract rather than undocumented drift.

## What changed

**`docs/NAMING-CONVENTION.md`** (new) — adapted from the CareerDossierTeX document. Defines a separate convention per GitHub object rather than forcing one style onto all of them:

| Object | Convention | Example |
|---|---|---|
| Issue title | `[area] Verb object` | `[organizer] Raise test coverage to 85 percent` |
| Branch | `type/short-description` | `test/organizer-coverage` |
| Commit / PR title | `type(scope): imperative summary` | `fix(packaging): drop the broken console script` |
| Label | `type:*` / `area:*` | `type:test`, `area:manage` |
| Milestone | `vX.Y.Z — Release Name` | `v0.5.0 — Trustworthy Ensemble Statistics` |

Commit types carry over from the source document unchanged; the scopes and area names are PolyPhys-specific.

**`AGENTS.md`** — points at that document and maps branch prefixes to the new type labels. Two prefixes change spelling (`feature/*` → `feat/*`), two are added (`test/*`, `ci/*`), and `area:*` becomes a second orthogonal axis. Adds the rule that status and priority belong in Project fields, not labels. The attribution rule and the "if the branch prefix and intended label disagree, stop and ask" rule are **unchanged**.

## Two defects found while migrating

1. **The PR template contradicted the repository.** It still prescribed:
   ```
   pytest polyphys --ignore=polyphys/tests/manage/test_parser.py --ignore=polyphys/manage/parser.py --ignore=polyphys/manage/organizer.py ...
   ```
   PR #3 removed those ignores, and issue #4's acceptance criteria explicitly require the suite to pass *without* them. Corrected, and the docs line now names the command CI actually runs.
2. **`dependabot.yml` declared no `labels:` key.** Dependabot recreates its default `dependencies` label when absent, which would have silently resurrected the very label this change renames. It now declares `type:deps` and `area:ci` explicitly.

## Deliberately minimal

Template *bodies* are untouched. Both PR checklists keep their content — including all three `## Scientific Correctness` items, which remain correct and domain-specific — and the three issue templates change only two front-matter fields each:

| File | `title:` | `labels:` |
|---|---|---|
| `bug_report.md` | `""` → `"[area] "` | `bug` → `type:bug` |
| `feature_request.md` | `""` → `"[area] "` | `enhancement` → `type:feature` |
| `question.md` | `""` → `"[area] "` | `question` → `type:question` |

The prefilled `title:` nudges the convention at the point of writing without touching content.

## Label migration (already applied)

The nine existing labels were **renamed in place** with `gh label edit --name` rather than recreated, so assignments on issue #4 and PRs #11/#12 are preserved — verified after the fact. Ten new labels were added. The repository now has 19.

## Verification

| Check | Result |
|---|---|
| `pytest polyphys README.md --cov=polyphys --cov-report=term-missing --doctest-modules --doctest-glob="README.md"` (the corrected template command) | **257 passed, 21 skipped** |
| `dependabot.yml` + all three issue-template front matters parse as YAML | valid |
| `grep` for stale label names in `AGENTS.md` | none remaining |

No source code is touched by this PR.

## Notes for review

- `docs/NAMING-CONVENTION.md` sits outside `docs/source/`, so Sphinx does not build it.
- Not included, deliberately: an **AI-assistance disclosure** section in the PR template. The source repo requires one, but that requirement is grounded in its `CONTRIBUTING.md` and `AI-POLICY.md`, neither of which poly-phys has. Adding the section without the policy behind it would be half a system; it belongs with that port.