### PR TITLE
docs(agents): add an AI usage policy and align the agent contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,12 @@ The live worktree and current GitHub metadata take precedence over stale prose. 
 
 ## Instruction scope and sources of truth
 
+- `AI-POLICY.md` governs AI use in this repository and takes precedence over this file. This file says how to do the work; the policy says what is permitted and who is accountable for it. Follow both, and do not restate the policy here.
 - These instructions apply repository-wide unless a more specific instruction file applies to the files being changed.
 - Put shared directory-specific guidance in a nested `AGENTS.md`. Add a sibling `CLAUDE.md` containing `@AGENTS.md`.
 - Keep nested guidance additive. When it replaces a root rule, name the replaced rule explicitly.
 - Use parallel agents only for independent tasks. Do not let multiple agents edit the same files concurrently; use separate branches or worktrees.
-- Canonical sources are `README.md`, `pyproject.toml`, `.github/workflows/`, `docs/source/`, `polyphys/__version__.py`, and `SECURITY.md`.
+- Canonical sources are `README.md`, `pyproject.toml`, `.github/workflows/`, `docs/source/`, `polyphys/__version__.py`, `CHANGELOG.md`, `CITATION.cff`, `docs/NAMING-CONVENTION.md`, `SECURITY.md`, and `AI-POLICY.md`.
 
 ## Project invariants
 
@@ -104,7 +105,8 @@ python -m build
 - For correlated molecular-dynamics frames, use block averaging or another autocorrelation-aware uncertainty estimate instead of naive per-frame standard errors.
 - Prefer vectorized NumPy, pandas, and MDAnalysis operations when they improve performance without obscuring correctness.
 - Document time and space complexity for every new or materially changed core routine whose cost scales with frames, particles, or dataset size.
-- Cite a verifiable paper, textbook, standard, or official library document for physical models, statistical methods, algorithms, and nontrivial formulas.
+- Cite a paper, textbook, standard, or official library document for physical models, statistical methods, algorithms, and nontrivial formulas. Confirm that the source exists and supports the claim before citing it; never cite from recall. An unverified citation is a defect.
+- Derive every numerical fixture and expected test value from an analytic result, a cited reference, or a reproducible computation, and say which in the PR. Never adopt a value because a model produced it, and never repair a failing test by replacing its expectation with the observed output.
 
 ## Git and draft PR policy
 
@@ -157,6 +159,7 @@ Obtain explicit approval before pushing changes involving:
 - After packaging, package-data, entry-point, or version-loading changes, run `python -m build` in the applicable environment.
 - For GitHub Actions, use least-privilege permissions, avoid privileged triggers that execute untrusted code, keep commands locally reproducible, and inspect failed job logs before proposing a fix.
 - Never expose, log, commit, or paste credentials, tokens, private keys, or sensitive datasets.
+- Never send repository secrets, unpublished simulation data, private datasets, or draft manuscripts to a third-party service, including any AI service. Work against the repository, not against research data.
 - Follow `SECURITY.md`: report suspected vulnerabilities privately and do not open a public issue or PR containing exploit details.
 - Security audits are read-only by default. Separate verified, likely-but-untested, and unassessed findings.
 - Before creating a tracked issue, inspect open and closed issues when network access is available; otherwise state that duplication was not checked.

--- a/AI-POLICY.md
+++ b/AI-POLICY.md
@@ -1,0 +1,130 @@
+# AI Policy
+
+PolyPhys is developed with the help of AI coding assistants. This document
+states how they are used, who is accountable for the result, and what they are
+not permitted to do.
+
+## 1. Scope
+
+This policy governs the `amirhs1/poly-phys` repository and the releases cut from
+it. It is a governance document written for people — users, reviewers, and
+researchers deciding whether to trust or cite this software.
+
+It is not the operating contract for the assistants themselves. That contract
+lives in [`AGENTS.md`](AGENTS.md), with tool-specific additions in
+[`CLAUDE.md`](CLAUDE.md). Those files describe *how* an agent works in this
+repository; this file describes *what is permitted and who answers for it*. Read
+this one first; the contract is subordinate to it.
+
+This policy does not govern the writing of manuscripts or the conduct of the
+research that PolyPhys supports. Those follow the policies of the relevant
+journal and institution.
+
+## 2. Human accountability
+
+The maintainer is accountable for every line merged into `main`, regardless of
+which tool drafted it. AI assistance changes how the work is produced; it does
+not transfer responsibility for the result.
+
+Concretely:
+
+- Every change is reviewed by the maintainer before it is merged. Assistants
+  open draft pull requests; they do not mark them ready, approve them, or merge
+  them.
+- Only the maintainer publishes a release, moves a tag, or changes repository
+  protections.
+- **AI systems are not authors.** No assistant appears in
+  [`CITATION.cff`](CITATION.cff) or [`AUTHORS.rst`](AUTHORS.rst), and none is
+  credited as a contributor to a release. A tool cannot take responsibility for
+  the work, which is what authorship means.
+
+## 3. How AI is used here
+
+Assistants are used to draft and revise code, tests, docstrings, and
+documentation; to refactor existing code; to review diffs; to triage and draft
+issues; and to write commit messages and pull-request descriptions.
+
+They are not used to produce research results. Specifically, no assistant is
+used to generate simulation data, to decide a scientific question, to invent a
+numerical value that a test then enshrines, or to supply a citation that is
+carried into the repository unchecked.
+
+The assistants currently in use are Claude Code and OpenAI Codex. This list will
+change; the rules in this document do not depend on which tool is in use.
+
+## 4. Scientific integrity
+
+PolyPhys produces numbers that end up in published work, so the ordinary risks
+of generated code are compounded by a specific one: a plausible-looking value,
+formula, or reference that no one ever verified. The following rules exist to
+close that gap.
+
+- **Expected values are derived, not asserted.** Every numerical fixture and
+  expected result in the test suite must come from an analytic derivation, a
+  published reference, or a reproducible computation. A value is never accepted
+  because a model produced it, and a failing test is never "fixed" by replacing
+  the expectation with the observed output.
+- **Doctest output comes from running the code.** Examples in docstrings and in
+  the README are executed by the test suite. Their output is copied from a real
+  run, never predicted.
+- **Citations are verified.** Physical models, statistical methods, algorithms,
+  and nontrivial formulas carry a citation to a paper, textbook, standard, or
+  official library document that has been confirmed to exist *and* to support
+  the claim being made. Language models fabricate plausible references; an
+  unverified citation is treated as a defect, not a formatting detail.
+- **Units, shapes, and assumptions are preserved.** Physical units, array-shape
+  contracts, numerical meaning, and established scientific assumptions are not
+  changed by a refactor. A changed expected value must be explained, with its
+  scientific basis, in the pull request that changes it.
+- **Verification is observed, not assumed.** No check, test, build, or benchmark
+  is reported as passing unless its successful result was actually seen.
+
+## 5. Provenance and attribution
+
+Commits and pull requests follow [`docs/NAMING-CONVENTION.md`](docs/NAMING-CONVENTION.md).
+AI-assisted commits carry the assistant's own configured attribution trailer, so
+the history records where a change came from without duplicating that
+information in the subject line. Agent and tool names do not appear as prefixes
+in commit subjects or pull-request titles.
+
+## 6. Security and data handling
+
+- Credentials, tokens, private keys, and configuration secrets are never
+  provided to an AI tool, in any form.
+- Unpublished simulation data, private datasets, and draft manuscripts are not
+  pasted into prompts or otherwise sent to a third-party service. Assistants
+  work against the repository, not against research data.
+- Assistants operate within the permissions, sandboxing, hooks, and branch
+  protections configured for them. Those controls are not to be weakened or
+  circumvented, and a denied action is not to be retried by another route.
+- Suspected vulnerabilities follow [`SECURITY.md`](SECURITY.md) and are reported
+  privately. Exploit details do not go into a public issue or pull request,
+  whether written by a person or a tool.
+
+## 7. Licensing
+
+PolyPhys is MIT-licensed, and everything merged into it must be distributable
+under that license. Generated output is treated like any other contribution: it
+must not reproduce substantial portions of code whose license is unknown or
+incompatible. Verbatim reproduction of a recognizable third-party implementation
+is a reason to stop and check the source, not a shortcut.
+
+## 8. Contributors
+
+Contributions are welcome, and using an AI assistant to prepare one is fine.
+Two conditions apply:
+
+1. **Disclose material assistance.** If an assistant drafted a substantial part
+   of the change, say so in the pull-request description. A one-line note is
+   enough.
+2. **You remain responsible for what you submit.** You should be able to explain
+   what the change does and why it is correct. A pull request consisting of
+   unreviewed model output is not a contribution, and will be closed.
+
+Everything in section 4 applies to contributed changes as well.
+
+## 9. Revision
+
+This policy will be revised as the tools, the project, and the surrounding norms
+change. Substantive changes go through a pull request like any other change, and
+are recorded in [`CHANGELOG.md`](CHANGELOG.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ Targeting `0.4.0`.
 - A README that states the problem the package solves, documents installation
   and the artifact-lineage model, and carries a quickstart whose examples are
   executed by the test suite.
+- `AI-POLICY.md`, stating how AI coding assistants are used in this repository,
+  that the maintainer is accountable for every merged change, that no AI system
+  is an author, and what AI-assisted contributions must satisfy — in particular
+  the scientific-integrity rules on derived expected values, executed doctest
+  output, and verified citations. `AGENTS.md` and `CLAUDE.md` now defer to it
+  and carry matching rules for citation verification, numerical fixtures, and
+  third-party data handling.
 
 ## [0.3.0] - 2025-07-10
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,10 @@
 
 ## Shared contract
 
-`AGENTS.md` is the canonical operating contract for every coding agent. Do not
-restate shared rules here; add only Claude Code-specific behavior.
+`AI-POLICY.md` governs AI use in this repository and takes precedence over both
+this file and `AGENTS.md`. `AGENTS.md` is the canonical operating contract for
+every coding agent. Do not restate the policy or shared rules here; add only
+Claude Code-specific behavior.
 
 ## Local and scoped instructions
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ If you use PolyPhys in published work, please cite the archived release. The DOI
 above resolves to the latest version; see [`CITATION.cff`](CITATION.cff) for
 machine-readable metadata, or use GitHub's *Cite this repository* button.
 
+## AI assistance
+
+PolyPhys is developed with the help of AI coding assistants. Every change is
+reviewed and merged by the maintainer, who is accountable for the result; no AI
+system is an author of this software or of any release. Numerical fixtures,
+formulas, and citations are derived or verified rather than accepted from a
+model — see [`AI-POLICY.md`](AI-POLICY.md) for the full policy, including what
+is expected of AI-assisted contributions.
+
 ## Contributing
 
 Bug reports and questions are welcome via


### PR DESCRIPTION
## Summary

- Adds a root `AI-POLICY.md`: the human-facing governance document stating how AI
  coding assistants are used here, that the maintainer is accountable for every
  merged line, and that no AI system is an author of the software or of a release.
- Keeps the split explicit: `AI-POLICY.md` says what is permitted and who answers
  for it; `AGENTS.md` and `CLAUDE.md` say how the work is done and now defer to
  the policy without restating it.
- Carries three rules into `AGENTS.md` because they bind agents at work — a
  citation must be confirmed to exist and to support its claim, an expected test
  value must be derived rather than adopted from a model, and research data must
  not reach a third-party service.
- Extends the `AGENTS.md` canonical-sources list, which also omitted
  `CHANGELOG.md`, `CITATION.cff`, and `docs/NAMING-CONVENTION.md`.
- Adds a short `## AI assistance` section to the README and a changelog entry.

Closes #24

## Checks

- [ ] `flake8 polyphys`
- [ ] `mypy polyphys/analyze polyphys/manage`
- [x] `pytest README.md --doctest-glob="README.md"` — 1 passed
- [ ] `python -m build` if packaging metadata, package data, or package layout changed
- [ ] `python -m sphinx -W -b html docs/source docs/_build` if `docs/source/` changed

Documentation only: no package code, tests, or packaging metadata are touched, so
the linting, typing, build, and Sphinx checks have nothing to act on. The README
doctests were run because the README changed; they pass.

## Scientific Correctness

- [x] No measurement/statistics behavior changed
- [x] Units, numerical fixtures, and domain assumptions are preserved or explained
- [x] Parser lineage and organizer vocabulary are unchanged, or matching parser tests/docs were updated

## Notes

Deliberately out of scope, and worth a separate decision:

- **`CONTRIBUTING.md`** does not exist, so contributor expectations live in
  section 8 of the policy for now. If a contributor guide is added later, that
  section should move and the policy should link to it.
- **An AI-disclosure checkbox in `.github/PULL_REQUEST_TEMPLATE.md`** would
  enforce section 8 at the point of contribution. Left out to keep this PR to the
  authorized scope.
- **Zenodo / release metadata.** Whether an AI-usage statement belongs in the
  archived record is a release decision, not a documentation one.
- **The Sphinx site** does not carry the policy. Adding `docs/source/ai-policy.md`
  would mean keeping two copies in sync; the README link is the single entry point
  for now.

Points to review before marking ready:

- Section 3 names Claude Code and OpenAI Codex as the assistants in use. Correct
  that list if it is incomplete.
- Section 2's authorship claim is the load-bearing sentence for a JOSS reviewer
  (#22) and for anyone citing the package; it should say exactly what you want on
  the record.
- Section 6 forbids sending unpublished simulation data and draft manuscripts to
  any AI service. That is stricter than current practice may be — confirm you want
  it stated as a rule.
